### PR TITLE
add parallel/regularized ALS estimation

### DIFF
--- a/ipca/ipca.py
+++ b/ipca/ipca.py
@@ -15,7 +15,7 @@ class IPCARegressor:
     ----------
 
     n_factors : int, default=1
-        The number of latent factors to estimate. Note, the number of
+        The total number of factors to estimate. Note, the number of
         estimated factors is automatically reduced by the number of
         pre-specified factors. For example, if n_factors = 2 and one
         pre-specified factor is passed, then IPCARegressor will estimate
@@ -29,7 +29,8 @@ class IPCARegressor:
         estimation is stopped
 
     iter_tol : float, default=10e-6
-        Tolerance threshold for stopping the alternating least squares procedure
+        Tolerance threshold for stopping the alternating least squares
+        procedure
     """
 
     def __init__(self, n_factors=1, intercept=False, max_iter=10000,
@@ -52,14 +53,15 @@ class IPCARegressor:
                 setattr(self, k, v)
 
 
-    def fit(self, P=None, PSF=None, refit=False, **kwds):
+    def fit(self, Panel=None, PSF=None, refit=False, alpha=0., l1_ratio=1.,
+            **kwargs):
         """
         Fits the regressor to the data using an alternating least squares
         scheme.
 
         Parameters
         ----------
-        P :  numpy array
+        Panel :  numpy array
             Panel of stacked data. Each row corresponds to an observation
             (i, t) where i denotes the entity index and t denotes
             the time index. The panel may be unbalanced. The number of unique
@@ -81,6 +83,13 @@ class IPCARegressor:
             instead use the stored values from the previous fit. Note, it is
             still necessary to pass the previously used P.
 
+        alpha : scalar
+            Regularizing constant for Gamma estimation.  If this is set to
+            zero then the estimation defaults to non-regularized.
+
+        l1_ratio : scalar
+            Ratio of l1 and l2 penalties for elastic net Gamma fit.
+
         Returns
         -------
 
@@ -89,8 +98,8 @@ class IPCARegressor:
             mapping between characteristics and factors loadings. If there
             are M many pre-specified factors in the model then the
             matrix returned is of dimension (L, (n_factors+M)).
-            If an intercept is included in the model, its loadings are returned
-            in the last column of Gamma.
+            If an intercept is included in the model, its loadings are
+            returned in the last column of Gamma.
 
         Factors : numpy array
             Array with dimensions (n_factors, T) containing the estimated
@@ -108,21 +117,21 @@ class IPCARegressor:
                 raise ValueError('Refit only possible after initial fit.')
 
         # Check panel input
-        if P is None:
+        if Panel is None:
             raise ValueError('Must pass panel input data.')
         else:
             # remove panel rows containing missing obs
-            P = P[~np.any(np.isnan(P), axis=1)]
+            Panel = Panel[~np.any(np.isnan(Panel), axis=1)]
 
         # Unpack the Panel
         if not refit:
-            X, W, val_obs = self._unpack_panel(P)
+            X, W, val_obs = self._unpack_panel(Panel)
         else:
-            P, X, W, val_obs = self.P, self.X, self.W, self.val_obs
+            Panel, X, W, val_obs = self.Panel, self.X, self.W, self.val_obs
 
         # Handle pre-specified factors
         if PSF is not None:
-            if np.size(PSF, axis=1) != np.size(np.unique(P[:, 1])):
+            if np.size(PSF, axis=1) != np.size(np.unique(Panel[:, 1])):
                 raise ValueError("""Number of PSF observations must match
                                  number of unique dates in panel P""")
             self.has_PSF = True
@@ -148,8 +157,9 @@ class IPCARegressor:
             self.n_factors_eff = self.n_factors
 
         # Check that enough features provided
-        if np.size(P, axis=1) - 3 < self.n_factors_eff:
-            raise ValueError('The number of factors requested exceeds number of features')
+        if np.size(Panel, axis=1) - 3 < self.n_factors_eff:
+            raise ValueError("""The number of factors requested exceeds number
+                              of features""")
 
         # Determine fit case - if intercept or PSF or both use PSFcase fitting
         # Note PSFcase in contrast to has_PSF is only indicating
@@ -157,9 +167,10 @@ class IPCARegressor:
         # only an intercept was passed.
         self.PSFcase = True if self.has_PSF or self.intercept else False
 
-
         # Run IPCA
-        Gamma, Factors = self._fit_ipca(X, W, P, PSF, val_obs, **kwds)
+        Gamma, Factors = self._fit_ipca(X, W, val_obs, Panel=Panel, PSF=PSF,
+                                        alpha=alpha, l1_ratio=l1_ratio,
+                                        **kwargs)
 
         # Store estimates
         if self.PSFcase:
@@ -177,7 +188,7 @@ class IPCARegressor:
 
         # Save unpacked panel for Re-fitting
         if not refit:
-            self.P = P
+            self.Panel = Panel
             self.PSF = PSF
             self.X = X
             self.W = W
@@ -185,17 +196,18 @@ class IPCARegressor:
 
         # Compute Goodness of Fit
         self.r2_total, self.r2_pred, self.r2_total_x, self.r2_pred_x = \
-            self._R2_comps(P=P)
+            self._R2_comps(Panel=Panel)
 
         return self.Gamma_Est, self.Factors_Est
 
-    def predict(self, P=None, mean_factor=False):
+
+    def predict(self, Panel=None, mean_factor=False):
         """
         Predicts fitted values for a previously fitted regressor
 
         Parameters
         ----------
-        P :  numpy array
+        Panel :  numpy array
             Panel of stacked data. Each row corresponds to an observation
             (i, t) where i denotes the entity index and t denotes
             the time index. The panel may be unbalanced. If an observation
@@ -222,26 +234,29 @@ class IPCARegressor:
             characteristics information.
         """
 
-        if P is None:
-            raise ValueError('A panel of characteristics data must be provided.')
+        if Panel is None:
+            raise ValueError("""A panel of characteristics data must be
+                              provided.""")
 
-        if np.any(np.isnan(P)):
-            raise ValueError('Cannot contain missing observations / nan values.')
-        N = np.size(P, axis=0)
+        if np.any(np.isnan(Panel)):
+            raise ValueError("""Cannot contain missing observations / nan
+                              values.""")
+        N = np.size(Panel, axis=0)
         Ypred = np.full((N), np.nan)
 
         mean_Factors_Est = np.mean(self.Factors_Est, axis=1).reshape((-1, 1))
 
         if mean_factor:
-            Ypred[:] = np.squeeze(P[:, 2:].dot(self.Gamma_Est)\
+            Ypred[:] = np.squeeze(Panel[:, 2:].dot(self.Gamma_Est)\
                 .dot(mean_Factors_Est))
         else:
 
             for t_i, t in enumerate(self.dates):
-                ix = (P[:, 1] == t)
-                Ypred[ix] = np.squeeze(P[ix, 2:].dot(self.Gamma_Est)\
+                ix = (Panel[:, 1] == t)
+                Ypred[ix] = np.squeeze(Panel[ix, 2:].dot(self.Gamma_Est)\
                     .dot(self.Factors_Est[:, t_i]))
         return Ypred
+
 
     def BS_Walpha(self, ndraws=1000, n_jobs=1, backend='loky'):
         """
@@ -257,7 +272,8 @@ class IPCARegressor:
             Value is either 'loky' or 'multiprocessing'
 
         n_jobs  : integer
-            Number of workers to be used. If -1, all available workers are used.
+            Number of workers to be used. If -1, all available workers are
+            used.
 
         Returns
         -------
@@ -288,6 +304,7 @@ class IPCARegressor:
         pval = np.sum(Walpha_b > Walpha)/ndraws
         return pval
 
+
     def BS_Wbeta(self, l, ndraws=1000, n_jobs=1, backend='loky'):
         """
         Test of instrument significance.
@@ -297,7 +314,9 @@ class IPCARegressor:
         ----------
 
         l   : integer
-            Position of the characteristics for which the bootstrap is to be carried out. For example, if there are 10 characteristics, l is in the range 0 to 9 (left-/right-inclusive).
+            Position of the characteristics for which the bootstrap is to be
+            carried out. For example, if there are 10 characteristics, l is in
+            the range 0 to 9 (left-/right-inclusive).
 
         ndraws  : integer, default=1000
             Number of bootstrap draws and re-estimations to be performed
@@ -337,13 +356,14 @@ class IPCARegressor:
 
         return pval
 
-    def predictOOS(self, P=None, mean_factor=False):
+
+    def predictOOS(self, Panel=None, mean_factor=False):
         """
         Predicts time t+1 observation using an out-of-sample design.
 
         Parameters
         ----------
-        P :  numpy array
+        Panel :  numpy array
             Panel of stacked data. Each row corresponds to an observation
             (i,t) where i denotes the entity index and t denotes
             the time index. All data must correspond to time t, i.e. all
@@ -373,17 +393,18 @@ class IPCARegressor:
             characteristics information.
         """
 
-        if P is None:
-            raise ValueError('A panel of characteristics data must be provided.')
+        if Panel is None:
+            raise ValueError("""A panel of characteristics data must be
+                              provided.""")
 
-        if len(np.unique(P[:, 1])) > 1:
+        if len(np.unique(Panel[:, 1])) > 1:
             raise ValueError('The panel must only have a single timestamp.')
 
-        N = np.size(P, axis=0)
+        N = np.size(Panel, axis=0)
         Ypred = np.full((N), np.nan)
 
         # Unpack the panel into Z, Y
-        Z, Y = P[:, 3:], P[:, 2]
+        Z, Y = Panel[:, 3:], Panel[:, 2]
 
         # Compute realized factor returns
         Numer = self.Gamma_Est.T.dot(Z.T).dot(Y)
@@ -398,10 +419,71 @@ class IPCARegressor:
 
         return Ypred
 
-    def _fit_ipca(self, X, W, P, PSF, val_obs, quiet=False, **kwds):
+
+    def _unpack_panel(self, Panel):
+        """ Converts a stacked panel of data where each row corresponds to an
+        observation (i, t) into a tensor of dimensions (N, L, T) where N is the
+        number of unique entities, L is the number of characteristics and T is
+        the number of unique dates
+
+        Parameters
+        ----------
+
+        Panel : Panel of data. Each row corresponds to an observation (i, t).
+                The columns are ordered in the following manner:
+                COLUMN 1: entity id (i)
+                COLUMN 2: time index (t)
+                COLUMN 3: depdent variable Y(i,t)
+                COLUMN 4 and following: L characteristics
+
+        Returns
+        -------
+        X: array-like
+            matrix of dimensions (L, T), containing the characteristics
+            weighted portfolios
+
+        W: array-like
+            matrix of dimension (L, L, T)
+
+        val_obs: array-like
+            matrix of dimension (T), containting the number of non missing
+            observations at each point in time
         """
-        Fits the regressor to the data using an alternating least squares
-        scheme.
+
+        dates = np.unique(Panel[:, 1])
+        ids = np.unique(Panel[:, 0])
+        T = np.size(dates, axis=0)
+        N = np.size(ids, axis=0)
+        L = np.size(Panel, axis=1) - 3
+        print('The panel dimensions are:')
+        print('n_samples:', N, ', L:', L, ', T:', T)
+
+        bar = progressbar.ProgressBar(maxval=T,
+                                      widgets=[progressbar.Bar('=', '[', ']'),
+                                               ' ', progressbar.Percentage()])
+        bar.start()
+        X = np.full((L, T), np.nan)
+        W = np.full((L, L, T), np.nan)
+        val_obs = np.full((T), np.nan)
+        for t_i, t in enumerate(dates):
+            ixt = (Panel[:, 1] == t)
+            val_obs[t_i] = np.sum(ixt)
+            # Define characteristics weighted matrices
+            X[:, t_i] = Panel[ixt, 3:].T.dot(Panel[ixt, 2])/val_obs[t_i]
+            W[:, :, t_i] = Panel[ixt, 3:].T.dot(Panel[ixt, 3:])/val_obs[t_i]
+            bar.update(t_i)
+        bar.finish()
+
+        # Store panel dimensions
+        self.ids, self.dates, self.T, self.N, self.L = ids, dates, T, N, L
+
+        return X, W, val_obs
+
+
+    def _fit_ipca(self, X, W, val_obs, Panel=None, PSF=None, quiet=False,
+                  **kwargs):
+        """
+        Fits the regressor to the data using alternating least squares
 
         Parameters
         ----------
@@ -410,8 +492,15 @@ class IPCARegressor:
 
         W : array_like of shape (L, L,T),
 
-        P: Panel of data. Each row corresponds to an observation (i, t). The
-            columns are ordered in the following manner:
+
+        val_obs: array-like
+            matrix of dimension (T), containting the number of non missing
+            observations at each point in time
+
+        Panel : optional, Panel of data.
+
+                Each row corresponds to an observation (i, t).
+                The columns are ordered in the following manner:
                 COLUMN 1: entity id (i)
                 COLUMN 2: time index (t)
                 COLUMN 3: depdent variable Y(i,t)
@@ -419,10 +508,6 @@ class IPCARegressor:
 
         PSF : optional, array-like of shape (M, T), i.e.
             pre-specified factors
-
-        val_obs: array-like
-            matrix of dimension (T), containting the number of non missing
-            observations at each point in time
 
         quiet   : optional, bool
             If true no text output will be produced
@@ -456,13 +541,12 @@ class IPCARegressor:
 
         while((iter <= self.max_iter) and (tol_current > self.iter_tol)):
 
+            Gamma_New, Factor_New = self._ALS_fit(Gamma_Old, W, X, val_obs,
+                                                  Panel=Panel, PSF=PSF,
+                                                  **kwargs)
             if self.PSFcase:
-                Gamma_New, Factor_New = self._ALS_PSF_fit(Gamma_Old, W, X, P,
-                                                          PSF, val_obs, **kwds)
                 tol_current = np.max(np.abs(Gamma_New - Gamma_Old))
             else:
-                Gamma_New, Factor_New = self._ALS_fit(Gamma_Old, W, X, P,
-                                                      val_obs, **kwds)
                 tol_current_G = np.max(np.abs(Gamma_New - Gamma_Old))
                 tol_current_F = np.max(np.abs(Factor_New - Factor_Old))
                 tol_current = max(tol_current_G, tol_current_F)
@@ -480,46 +564,58 @@ class IPCARegressor:
         return Gamma_New, Factor_New
 
 
-    def _ALS_PSF_fit(self, Gamma_Old, W, X, P, PSF, val_obs, n_jobs=1,
-                     backend="loky", **kwds):
-        """Alternating least squares procedure to fit params for PSF case
+    def _ALS_fit(self, Gamma_Old, W, X, val_obs, Panel=None, PSF=None,
+                 n_jobs=1, backend="loky", alpha=0., l1_ratio=1., **kwargs):
+        """Alternating least squares procedure to fit params
 
         The alternating least squares procedure switches back and forth
         between evaluating the first order conditions for Gamma_Beta, and the
         factors until convergence is reached. This function carries out one
         complete update procedure and will need to be called repeatedly using
         the updated Gamma's and factors as inputs.
-
-        Parameters
-        ----------
-        Gamma_Old
-
-        Returns
-        -------
         """
 
         T = self.T
 
-        # Determine nunmber of factors to be estimated
-        K_PSF, _ = np.shape(PSF)
-        L, Ktilde = np.shape(Gamma_Old)
-        K = Ktilde - K_PSF
+        if PSF is None:
+            L, K = np.shape(Gamma_Old)
+            Ktilde = K
+        else:
+            L, Ktilde = np.shape(Gamma_Old)
+            K_PSF, _ = np.shape(PSF)
+            K = Ktilde - K_PSF
 
         # ALS Step 1
         if K > 0:
 
-            if n_jobs > 1:
-                F_New = Parallel(n_jobs=n_jobs, backend=backend)(
-                            delayed(_FT_PSFcase_fit)(
-                                Gamma_Old, W[:,:,t], X[:,t], PSF[:,t],
-                                K, Ktilde)
-                            for t in range(T))
-                F_New = np.stack(F_New, axis=1)
+            # case with no observed factors
+            if PSF is None:
+                if n_jobs > 1:
+                    F_New = Parallel(n_jobs=n_jobs, backend=backend)(
+                                delayed(_FT_fit)(
+                                    Gamma_Old, W[:,:,t], X[:,t])
+                                for t in range(T))
+                    F_New = np.stack(F_New, axis=1)
 
+                else:
+                    F_New = np.full((K, T), np.nan)
+                    for t in range(T):
+                        F_New[:,t] = _Ft_fit(Gamma_Old, W[:,:,t], X[:,t])
+
+            # observed factors+latent factors case
             else:
-                F_New = np.full((K, T), np.nan)
-                for t in range(T):
-                    F_New[:,t] = _Ft_PSFcase_fit(Gamma_Old, W[:,:,t], X[:,t],
+                if n_jobs > 1:
+                    F_New = Parallel(n_jobs=n_jobs, backend=backend)(
+                                delayed(_FT_PSF_fit)(
+                                    Gamma_Old, W[:,:,t], X[:,t], PSF[:,t],
+                                    K, Ktilde)
+                                for t in range(T))
+                    F_New = np.stack(F_New, axis=1)
+
+                else:
+                    F_New = np.full((K, T), np.nan)
+                    for t in range(T):
+                        F_New[:,t] = _Ft_PSF_fit(Gamma_Old, W[:,:,t], X[:,t],
                                                  PSF[:,t], K, Ktilde)
 
         else:
@@ -527,19 +623,12 @@ class IPCARegressor:
 
         # ALS Step 2
 
-        # join observed factors with latent factors and map to panel
-        if F_New is None:
-            F = PSF
+        if Panel is None:
+            Gamma_New = _Gamma_portfolio_fit(F_New, X, W, val_obs, PSF, L, K,
+                                             Ktilde, T)
         else:
-            F = np.vstack((F_New, PSF))
-        F = F[:,np.unique(P[:,1], return_inverse=True)[1]]
-
-        # interact factors and characteristics
-        ZkF = np.hstack((F[k,:,None] * P[:,3:] for k in range(Ktilde)))
-
-        # fit regression for Gamma
-        Gamma_New = _Gamma_fit(ZkF, P[:,2], **kwds)
-        Gamma_New = Gamma_New.reshape((Ktilde, L)).T
+            Gamma_New = _Gamma_panel_fit(F_New, Panel, PSF, L, Ktilde, alpha,
+                                         l1_ratio, **kwargs)
 
         # condition checks
 
@@ -561,133 +650,7 @@ class IPCARegressor:
         return Gamma_New, F_New
 
 
-    def _ALS_fit(self, Gamma_Old, W, X, val_obs, PSF=None, n_jobs=1,
-                 backend="loky", **kwds):
-        """Alternating least squares procedure to fit params
-
-        The alternating least squares procedure switches back and forth
-        between evaluating the first order conditions for Gamma_Beta, and the
-        factors until convergence is reached. This function carries out one
-        complete update procedure and will need to be called repeatedly using
-        the updated Gamma's and factors as inputs.
-
-        Parameters
-        ----------
-        Gamma_Old
-
-        Returns
-        -------
-        """
-
-        T = self.T
-
-        # Determine number of factors to be estimated
-        L, K = np.shape(Gamma_Old)
-        Ktilde = K
-
-        # ALS Step 1
-        if K > 0:
-
-            if n_jobs > 1:
-                F_New = Parallel(n_jobs=n_jobs, backend=backend)(
-                            delayed(_Ft_fit)(
-                                Gamma_Old, W[:,:,t], X[:,t])
-                            for t in range(T))
-                F_New = np.stack(F_New, axis=1)
-
-            else:
-                F_New = np.full((K, T), np.nan)
-                for t in range(T):
-                    F_New[:,t] = _Ft_fit(Gamma_Old, W[:,:,t], X[:,t])
-
-        else:
-            F_New = None
-
-        # ALS Step 2
-
-        # map factors to panel
-        F = F_New[:,np.unique(P[:,1], return_inverse=True)[1]]
-
-        # condition checks
-
-        # interact factors and characteristics
-        ZkF = np.hstack((F[k,:,None] * P[:,3:] for k in range(Ktilde)))
-
-        # fit regression for Gamma
-        Gamma_New = _Gamma_fit(ZkF, P[:,2], **kwds)
-        print(Gamma_New)
-        Gamma_New = Gamma_New.reshape((Ktilde, L)).T
-
-        # Enforce sign convention for Gamma_Beta and F_New
-        if K > 0:
-            sg = np.sign(np.mean(F_New, axis=1)).reshape((-1, 1))
-            sg[sg == 0] = 1
-            Gamma_New[:, :K] = np.multiply(Gamma_New[:, :K], sg.T)
-            F_New = np.multiply(F_New, sg)
-
-        return Gamma_New, F_New
-
-
-    def _unpack_panel(self, P):
-        """ Converts a stacked panel of data where each row corresponds to an
-        observation (i, t) into a tensor of dimensions (N, L, T) where N is the
-        number of unique entities, L is the number of characteristics and T is
-        the number of unique dates
-
-        Parameters
-        ----------
-
-        P: Panel of data. Each row corresponds to an observation (i, t). The
-            columns are ordered in the following manner:
-                COLUMN 1: entity id (i)
-                COLUMN 2: time index (t)
-                COLUMN 3: depdent variable Y(i,t)
-                COLUMN 4 and following: L characteristics
-
-        Returns
-        -------
-        X: array-like
-            matrix of dimensions (L, T), containing the characteristics
-            weighted portfolios
-
-        W: array-like
-            matrix of dimension (L, L, T)
-
-        val_obs: array-like
-            matrix of dimension (T), containting the number of non missing
-            observations at each point in time
-        """
-
-        dates = np.unique(P[:, 1])
-        ids = np.unique(P[:, 0])
-        T = np.size(dates, axis=0)
-        N = np.size(ids, axis=0)
-        L = np.size(P, axis=1) - 3
-        print('The panel dimensions are:')
-        print('n_samples:', N, ', L:', L, ', T:', T)
-
-        bar = progressbar.ProgressBar(maxval=T,
-                                      widgets=[progressbar.Bar('=', '[', ']'),
-                                               ' ', progressbar.Percentage()])
-        bar.start()
-        X = np.full((L, T), np.nan)
-        W = np.full((L, L, T), np.nan)
-        val_obs = np.full((T), np.nan)
-        for t_i, t in enumerate(dates):
-            ixt = (P[:, 1] == t)
-            val_obs[t_i] = np.sum(ixt)
-            # Define characteristics weighted matrices
-            X[:, t_i] = P[ixt, 3:].T.dot(P[ixt, 2])/val_obs[t_i]
-            W[:, :, t_i] = P[ixt, 3:].T.dot(P[ixt, 3:])/val_obs[t_i]
-            bar.update(t_i)
-        bar.finish()
-
-        # Store panel dimensions
-        self.ids, self.dates, self.T, self.N, self.L = ids, dates, T, N, L
-
-        return X, W, val_obs
-
-    def _R2_comps(self, P=None):
+    def _R2_comps(self, Panel=None):
         """
         Computes the goodness of fit measures both at the entity level
         and at the managed portfolio level. Requires the estimator to be
@@ -695,29 +658,31 @@ class IPCARegressor:
 
         Parameters
         ----------
-        P   :   Panel of stacked data. Each row corresponds to an observation
-                (i, t) where i denotes the entity index and t denotes
-                the time index. The panel may be unbalanced. The number of unique
-                entities is n_samples, the number of unique dates is T, and
-                the number of characteristics used as instruments is L.
-                The columns of the panel are organized in the following order:
+        Panel   :   Panel of stacked data. Each row corresponds to an
+                    observation (i, t) where i denotes the entity index and t
+                    denotes the time index. The panel may be unbalanced. The
+                    number of unique entities is n_samples, the number of
+                    unique dates is T, and the number of characteristics used
+                    as instruments is L. The columns of the panel are
+                    organized in the following order:
 
                 - Column 1: entity id (i)
                 - Column 2: time index (t)
-                - Column 3: dependent variable corresponding to observation (i,t)
+                - Column 3: dependent variable corresponding to observation
+                            (i,t)
                 - Column 4 to column 4+L: characteristics.
 
         """
 
         # Compute goodness of fit measures, entity level
-        Ytrue = P[:, 2]
+        Ytrue = Panel[:, 2]
 
         # R2 Total
-        Ypred = self.predict(np.delete(P, 2, axis=1), mean_factor=False)
+        Ypred = self.predict(np.delete(Panel, 2, axis=1), mean_factor=False)
         r2_total = 1-np.nansum((Ypred-Ytrue)**2)/np.nansum(Ytrue**2)
 
         # R2 Pred
-        Ypred = self.predict(np.delete(P, 2, axis=1), mean_factor=True)
+        Ypred = self.predict(np.delete(Panel, 2, axis=1), mean_factor=True)
         r2_pred = 1-np.nansum((Ypred-Ytrue)**2)/np.nansum(Ytrue**2)
 
         # Compute goodness of fit measures, portfolio level
@@ -745,8 +710,18 @@ class IPCARegressor:
         return r2_total, r2_pred, r2_total_x, r2_pred_x
 
 
-def _Ft_PSFcase_fit(Gamma_Old, W_t, X_t, PSF_t, K, Ktilde):
-    """helper func to parallelize PSFcase F ALS fit"""
+
+def _Ft_fit(Gamma_Old, W_t, X_t):
+    """helper func to parallelize F ALS fit"""
+
+    m1 = Gamma_Old.T.dot(W_t).dot(Gamma_Old)
+    m2 = Gamma_Old.T.dot(X_t)
+
+    return np.squeeze(_numba_solve(m1, m2.reshape((-1, 1))))
+
+
+def _Ft_PSF_fit(Gamma_Old, W_t, X_t, PSF_t, K, Ktilde):
+    """helper func to parallelize F ALS fit with observed factors"""
 
     m1 = Gamma_Old[:,:K].T.dot(W_t).dot(Gamma_Old[:,:K])
     m2 = Gamma_Old[:,:K].T.dot(X_t)
@@ -755,29 +730,121 @@ def _Ft_PSFcase_fit(Gamma_Old, W_t, X_t, PSF_t, K, Ktilde):
     return np.squeeze(_numba_solve(m1, m2.reshape((-1, 1))))
 
 
-def _Ft_fit(Gamma_Old, W_t, X_t):
-    """helper func to parallelize base F ALS fit"""
+def _Gamma_portfolio_fit(F_New, X, W, val_obs, PSF, L, K, Ktilde, T):
+    """helper function for fitting gamma without panel"""
 
-    m1 = Gamma_Old.T.dot(W_t).dot(Gamma_Old)
-    m2 = Gamma_Old.T.dot(X_t)
+    Numer = _numba_full((L*Ktilde, 1), 0.0)
+    Denom = _numba_full((L*Ktilde, L*Ktilde), 0.0)
 
-    return np.squeeze(_numba_solve(m1, m2.reshape((-1, 1))))
+    # no observed factors
+    if PSF is None:
+        for t in range(T):
+
+            Numer += _numba_kron(X[:, t].reshape((-1, 1)),
+                                 F_New[:, t].reshape((-1, 1)))\
+                                 * val_obs[t]
+            Denom += _numba_kron(W[:, :, t],
+                                 F_New[:, t].reshape((-1, 1))
+                                 .dot(F_New[:, t].reshape((1, -1)))) \
+                                 * val_obs[t]
+
+    # observed+latent factors
+    elif K > 0:
+        for t in range(T):
+            Numer += _numba_kron(X[:, t].reshape((-1, 1)),
+                                 np.vstack(
+                                 (F_New[:, t].reshape((-1, 1)),
+                                 PSF[:, t].reshape((-1, 1)))))\
+                                 * val_obs[t]
+            Denom_temp = np.vstack((F_New[:, t].reshape((-1, 1)),
+                                   PSF[:, t].reshape((-1, 1))))
+            Denom += _numba_kron(W[:, :, t], Denom_temp.dot(Denom_temp.T)
+                                 * val_obs[t])
+
+    # only observed factors
+    else:
+        for t in range(T):
+            Numer += _numba_kron(X[:, t].reshape((-1, 1)),
+                                 PSF[:, t].reshape((-1, 1)))\
+                                 * val_obs[t]
+            Denom += _numba_kron(W[:, :, t],
+                                 PSF[:, t].reshape((-1, 1))
+                                 .dot(PSF[:, t].reshape((-1, 1)).T))\
+                                 * val_obs[t]
+
+    Gamma_New = _numba_solve(Denom, Numer).reshape((L, Ktilde))
+
+    return Gamma_New
 
 
-def _Gamma_fit(ZkF, y, alpha=0., fit_intercept=False, **kwds):
-    """helper function for estimating vectorized Gamma"""
+def _Gamma_panel_fit(F_New, Panel, PSF, L, Ktilde, alpha, l1_ratio, **kwargs):
+    """helper function for estimating vectorized Gamma with panel"""
+
+    # join observed factors with latent factors and map to panel
+    if PSF is None:
+        F = F_New
+    else:
+        if F_New is None:
+            F = PSF
+        else:
+            F = np.vstack((F_New, PSF))
+    F = F[:,np.unique(Panel[:,1], return_inverse=True)[1]]
+
+    # interact factors and characteristics
+    ZkF = np.hstack((F[k,:,None] * Panel[:,3:] for k in range(Ktilde)))
 
     # elastic net fit
     if alpha:
-        mod = ElasticNet(alpha=alpha, fit_intercept=fit_intercept, **kwds)
-        mod.fit(ZkF, y)
+        mod = ElasticNet(alpha=alpha, l1_ratio=l1_ratio, **kwargs)
+        mod.fit(ZkF, Panel[:,2])
         gamma = mod.coef_
 
     # OLS fit
     else:
-        gamma = _numba_lstsq(ZkF, y)[0]
+        gamma = _numba_lstsq(ZkF, Panel[:,2])[0]
+
+    gamma = gamma.reshape((Ktilde, L)).T
 
     return gamma
+
+
+def _BS_Walpha_sub(model, n, d):
+    X_b = np.full((model.L, model.T), np.nan)
+    np.random.seed(n)
+    for t in range(model.T):
+        d_temp = np.random.standard_t(5)*d[:,np.random.randint(0,high=model.T)]
+        X_b[:, t] = model.W[:, :, t].dot(model.Gamma_Est[:, :-1])\
+            .dot(model.Factors_Est[:-1, t]) + d_temp
+
+    # Re-estimate unrestricted model
+    Gamma, Factors = model._fit_ipca(X=X_b, W=model.W, val_obs=model.val_obs,
+                                     PSF=model.PSF, quiet=True)
+
+    # Compute and store Walpha_b
+    Walpha_b = Gamma[:, -1].T.dot(Gamma[:, -1])
+
+    return Walpha_b
+
+
+def _BS_Wbeta_sub(model, n, d, l):
+    X_b = np.full((model.L, model.T), np.nan)
+    np.random.seed(n)
+    #Modify Gamma_beta such that its l-th row is zero
+    Gamma_beta_l = np.copy(model.Gamma_Est)
+    Gamma_beta_l[l, :] = 0
+    for t in range(model.T):
+        d_temp = np.random.standard_t(5)*d[:,np.random.randint(0,high=model.T)]
+        X_b[:, t] = model.W[:, :, t].dot(Gamma_beta_l)\
+            .dot(model.Factors_Est[:, t]) + d_temp
+
+    # Re-estimate unrestricted model
+    Gamma, Factors = model._fit_ipca(X=X_b, W=model.W, val_obs=model.val_obs,
+                                     PSF=model.PSF, quiet=True)
+
+    # Compute and store Walpha_b
+    Wbeta_l_b = Gamma[l, :].dot(Gamma[l, :].T)
+    Wbeta_l_b = np.trace(Wbeta_l_b)
+    return Wbeta_l_b
 
 
 @jit(nopython=True)
@@ -803,42 +870,3 @@ def _numba_svd(m1):
 @jit(nopython=True)
 def _numba_full(m1, m2):
     return np.full(m1, m2)
-
-
-def _BS_Walpha_sub(self, n, d):
-    X_b = np.full((self.L, self.T), np.nan)
-    np.random.seed(n)
-    for t in range(self.T):
-        d_temp = np.random.standard_t(5)*d[:, np.random.randint(0, high=self.T)]
-        X_b[:, t] = self.W[:, :, t].dot(self.Gamma_Est[:, :-1])\
-            .dot(self.Factors_Est[:-1, t]) + d_temp
-
-    # Re-estimate unrestricted model
-    Gamma, Factors = self._fit_ipca(X=X_b, W=self.W, PSF=self.PSF,
-                                    val_obs=self.val_obs, quiet=True)
-
-    # Compute and store Walpha_b
-    Walpha_b = Gamma[:, -1].T.dot(Gamma[:, -1])
-
-    return Walpha_b
-
-
-def _BS_Wbeta_sub(self, n, d, l):
-    X_b = np.full((self.L, self.T), np.nan)
-    np.random.seed(n)
-    #Modify Gamma_beta such that its l-th row is zero
-    Gamma_beta_l = np.copy(self.Gamma_Est)
-    Gamma_beta_l[l, :] = 0
-    for t in range(self.T):
-        d_temp = np.random.standard_t(5)*d[:, np.random.randint(0, high=self.T)]
-        X_b[:, t] = self.W[:, :, t].dot(Gamma_beta_l)\
-            .dot(self.Factors_Est[:, t]) + d_temp
-
-    # Re-estimate unrestricted model
-    Gamma, Factors = self._fit_ipca(X=X_b, W=self.W, PSF=self.PSF,
-                                    val_obs=self.val_obs, quiet=True)
-
-    # Compute and store Walpha_b
-    Wbeta_l_b = Gamma[l, :].dot(Gamma[l, :].T)
-    Wbeta_l_b = np.trace(Wbeta_l_b)
-    return Wbeta_l_b

--- a/ipca/ipca.py
+++ b/ipca/ipca.py
@@ -457,7 +457,7 @@ class IPCARegressor:
         while((iter <= self.max_iter) and (tol_current > self.iter_tol)):
 
             if self.PSFcase:
-                Gamma_New, Factor_New = self._ALS_PFS_fit(Gamma_Old, W, X, P,
+                Gamma_New, Factor_New = self._ALS_PSF_fit(Gamma_Old, W, X, P,
                                                           PSF, val_obs, **kwds)
                 tol_current = np.max(np.abs(Gamma_New - Gamma_Old))
             else:
@@ -480,9 +480,9 @@ class IPCARegressor:
         return Gamma_New, Factor_New
 
 
-    def _ALS_PFS_fit(self, Gamma_Old, W, X, P, PSF, val_obs, n_jobs=1,
+    def _ALS_PSF_fit(self, Gamma_Old, W, X, P, PSF, val_obs, n_jobs=1,
                      backend="loky", **kwds):
-        """Alternating least squares procedure to fit params for PFS case
+        """Alternating least squares procedure to fit params for PSF case
 
         The alternating least squares procedure switches back and forth
         between evaluating the first order conditions for Gamma_Beta, and the

--- a/ipca/test_ipca.py
+++ b/ipca/test_ipca.py
@@ -34,7 +34,7 @@ PSF = PSF.reshape((2, -1))
 
 # Test IPCARegressor
 regr = IPCARegressor(n_factors=1, intercept=False)
-Gamma_New, Factor_New = regr.fit(P=data)
+Gamma_New, Factor_New = regr.fit(Panel=data)
 print('R2total', regr.r2_total)
 print('R2pred', regr.r2_pred)
 print('R2total_x', regr.r2_total_x)
@@ -45,7 +45,7 @@ print(Factor_New)
 
 # Test IPCARegressor with intercept
 regr = IPCARegressor(n_factors=1, intercept=True)
-Gamma_New, Factor_New = regr.fit(P=data)
+Gamma_New, Factor_New = regr.fit(Panel=data)
 print('R2total', regr.r2_total)
 print('R2pred', regr.r2_pred)
 print('R2total_x', regr.r2_total_x)
@@ -54,40 +54,40 @@ print('R2pred_x', regr.r2_pred_x)
 
 # Use the fitted regressor to predict
 data_x = np.delete(data, 2, axis=1)
-Ypred = regr.predict(P=data_x)
+Ypred = regr.predict(Panel=data_x)
 
 # Test refitting the IPCARegressor with previous data but different n_factors
 regr.n_factors = 2
 regr.intercept = False
-Gamma_New, Factor_New = regr.fit(P=data, refit=True)
+Gamma_New, Factor_New = regr.fit(Panel=data, refit=True)
 
 # Test refitting the IPCARegressor on new data
 data_refit = data[data[:, 1] != 1954, :]
-Gamma_New, Factor_New = regr.fit(P=data_refit, refit=False)
+Gamma_New, Factor_New = regr.fit(Panel=data_refit, refit=False)
 
 # Test PSF - one additional factor estimated
 PSF = np.random.randn(len(np.unique(data[:, 1])), 1)
 PSF = PSF.reshape((1, -1))
 regr = IPCARegressor(n_factors=2, intercept=False)
-Gamma_New, Factor_New = regr.fit(P=data, PSF=PSF, refit=False)
+Gamma_New, Factor_New = regr.fit(Panel=data, PSF=PSF, refit=False)
 
 # Test PSF - no additional factors estimated
 PSF = np.random.randn(len(np.unique(data[:, 1])), 2)
 PSF = PSF.reshape((2, -1))
 regr = IPCARegressor(n_factors=2, intercept=False)
-Gamma_New, Factor_New = regr.fit(P=data, PSF=PSF, refit=False)
+Gamma_New, Factor_New = regr.fit(Panel=data, PSF=PSF, refit=False)
 
 # Test nan observations
 regr = IPCARegressor(n_factors=1, intercept=True)
 data_nan = data.copy()
 data_nan[10:30, 2:] = np.nan
-Gamma_New, Factor_New = regr.fit(P=data_nan)
+Gamma_New, Factor_New = regr.fit(Panel=data_nan)
 
 # Test missing observations
 regr = IPCARegressor(n_factors=1, intercept=True)
 data_missing = data.copy()
 data_missing = data_missing[:-10, :]
-Gamma_New, Factor_New = regr.fit(P=data_missing)
+Gamma_New, Factor_New = regr.fit(Panel=data_missing)
 
 # Simulate OOS experiment
 # In-sample data excludes observations during last available date
@@ -95,17 +95,25 @@ data_IS = data[data[:, 1] != 1954, :]
 # Out-of-sample consists only of observation at last available date
 data_OOS = data[data[:, 1] == 1954, :]
 # Re-fit the regressor
-regr.fit(P=data_IS)
-Ypred = regr.predictOOS(P=data_OOS, mean_factor=True)
+regr.fit(Panel=data_IS)
+Ypred = regr.predictOOS(Panel=data_OOS, mean_factor=True)
 
 # Test Walpha Bootstrap
 regr = IPCARegressor(n_factors=1, intercept=True)
-Gamma_New, Factor_New = regr.fit(P=data)
+Gamma_New, Factor_New = regr.fit(Panel=data)
 pval = regr.BS_Walpha(ndraws=10)
 print('p-value', pval)
 
 # Test Wbeta Bootstrap
 regr = IPCARegressor(n_factors=1, intercept=False)
-Gamma_New, Factor_New = regr.fit(P=data)
+Gamma_New, Factor_New = regr.fit(Panel=data)
 pval = regr.BS_Wbeta([0, 1], ndraws=10, n_jobs=-1)
 print('p-value', pval)
+
+# Test with regularization
+regr = IPCARegressor(n_factors=2, intercept=False)
+Gamma_New, Factor_New = regr.fit(Panel=data, alpha=0.5)
+Gamma_New, Factor_New = regr.fit(Panel=data, alpha=0.5, l1_ratio=0.5)
+Gamma_New, Factor_New = regr.fit(Panel=data, PSF=PSF, alpha=0.5)
+regr = IPCARegressor(n_factors=1, intercept=True)
+Gamma_New, Factor_New = regr.fit(Panel=data, alpha=0.5)

--- a/ipca/test_ipca.py
+++ b/ipca/test_ipca.py
@@ -18,7 +18,7 @@ def test_construction_errors():
 # Create test data and run package
 data = grunfeld.load_pandas().data
 data.year = data.year.astype(np.int64)
-data.firm = data.firm.apply(lambda x: x.decode('utf-8'))
+#data.firm = data.firm.apply(lambda x: x.decode('utf-8'))
 # Establish unique IDs to conform with package
 N = len(np.unique(data.firm))
 ID = dict(zip(np.unique(data.firm).tolist(), np.arange(1, N+1)+5))


### PR DESCRIPTION
@matbuechner I've made some changes which do the following:

1. Add parallel estimation for the factors
2. Add regularized estimation for the Gammas

There are a couple of key points to note:

1. The elastic net estimation for Gamma is easiest when we work off the original panel.  As a result, I've kept a copy of that in the IPCARegressor class.  Currently, I'm using the panel for all Gamma estimation variants.  

    However, after I put this together, I realized that that breaks the p-values.  It may make the most sense to carry around a copy of both the full panel and the portfolios, though you may have some ideas for an easy way to just keep one.  I'm going to experiment with this further.

2. Currently, I've split the ALS procedure for PSF cases from the base case (which cuts down on the if statements).  That said, I'm rethinking whether this is the right choice, and will likely rejoin these to clean things up.

3. To handle the elastic net, I'm currently using sklearn's implementation:

    https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNet.html

    This obviously adds another dependency but if there is going to be regularized estimation at all this seems unavoidable.

Overall, let me know if you have any thoughts.

Further things I'd like to do before this is merged:

- [x] Add some formal tests for the regularized estimation
- [x] Determine how best to handle the portfolio/panel data
- [x] Rejoin PSF/base ALS functions

